### PR TITLE
Fix diff pane not changing line ending properly

### DIFF
--- a/lib/buffer-extender.js
+++ b/lib/buffer-extender.js
@@ -1,6 +1,6 @@
 'use babel'
 
-module.exports = class BufferExtender {
+class BufferExtender {
   _buffer: Object;
 
   constructor(buffer) {
@@ -31,3 +31,7 @@ module.exports = class BufferExtender {
     }
   }
 };
+
+BufferExtender.LINE_ENDING_REGEXP = /\r\n|\n|\r/g;
+
+module.exports = BufferExtender;

--- a/lib/split-diff.coffee
+++ b/lib/split-diff.coffee
@@ -347,8 +347,9 @@ module.exports = SplitDiff =
       atom.views.getView(editor1).focus()
       # set the preferred line ending before inserting text if there is no git repo #39
       if buffer1LineEnding == '\n' || buffer1LineEnding == '\r\n'
-        @editorSubscriptions.add editor2.onWillInsertText () ->
-          editor2.getBuffer().setPreferredLineEnding(buffer1LineEnding)
+        buffer2 = editor2.getBuffer()
+        buffer2.setPreferredLineEnding(buffer1LineEnding)
+        buffer2.setText(buffer2.getText().replace(BufferExtender.LINE_ENDING_REGEXP, buffer1LineEnding))
     else if buffer2LineEnding != '' && (buffer1LineEnding != buffer2LineEnding)
       # pop warning if the line endings differ and we haven't done anything about it
       lineEndingMsg = 'Warning: Editor line endings differ!'


### PR DESCRIPTION
There are two issues here:
1. The onWillInsertText method is never being called
2. The buffer holds the file contents already, so we need to change its line endings as in https://github.com/atom/line-ending-selector/blob/master/lib/main.js, line 134

This fix removes the use of the onWillInsertText callback and updates the editor's content immediately. Tested and working on Windows 10.