### PR TITLE
Fix cursor line selected color

### DIFF
--- a/lib/editor-diff-extender.js
+++ b/lib/editor-diff-extender.js
@@ -41,7 +41,7 @@ module.exports = class EditorDiffExtender {
    */
   highlightLines(startIndex, endIndex, highlightType) {
     if(startIndex != endIndex) {
-      var highlightClass = 'split-diff-' + highlightType;
+      var highlightClass = 'split-diff-line split-diff-' + highlightType;
       this._createLineMarker(this._lineMarkerLayer, startIndex, endIndex, highlightClass);
     }
   }

--- a/styles/split-diff.less
+++ b/styles/split-diff.less
@@ -4,16 +4,18 @@
 atom-text-editor {
   .gutter .line-number,
   .line {
-    &.split-diff-added {
-      background-color: fade(@syntax-color-added, 40%);
-    }
+    &.split-diff-line {
+      &.split-diff-added {
+        background-color: fade(@syntax-color-added, 40%);
+      }
 
-    &.split-diff-removed {
-      background-color: fade(@syntax-color-removed, 40%);
-    }
+      &.split-diff-removed {
+        background-color: fade(@syntax-color-removed, 40%);
+      }
 
-    &.split-diff-selected {
-      background-color: fade(@syntax-color-modified, 40%);
+      &.split-diff-selected {
+        background-color: fade(@syntax-color-modified, 40%);
+      }
     }
   }
 


### PR DESCRIPTION
Hi, mupchrch!

I think there is a problem with the diff chunk highlight. The diff color is overridden by the syntax-theme cursor line.

eg:
The [one-dark syntax theme](https://github.com/atom/one-dark-syntax/blob/master/styles/editor.less#L8) defines the `.cursor-line` with `atom-text-editor .line.cursor-line`. So it will take over the `atom-text-editor .line.split-diff-selected`. Which makes the chunk looks strange.

I fix this by adding an additional class `split-diff-line` to the highlighted lines and line numbers. So the css can take higher priority.

Here is the demo:

Before
![rec1](https://user-images.githubusercontent.com/6789491/29778913-8999d508-8c43-11e7-8f21-8ca129fc1cb4.gif)

After that
![rec2](https://user-images.githubusercontent.com/6789491/29779057-faf3cd8a-8c43-11e7-8ee7-05f18973ae3e.gif)
